### PR TITLE
Handle redirecting user to original url using query parameter

### DIFF
--- a/src/BlazorAuthenticationSample.Client/Features/Account/Pages/SignIn.razor
+++ b/src/BlazorAuthenticationSample.Client/Features/Account/Pages/SignIn.razor
@@ -3,7 +3,6 @@
 @inject SignInManager<IdentityUser> signInManager
 @inject NavigationManager navigationManager
 @inject IDataProtectionProvider dataProtectionProvider
-@inject SignInRedirectContext signInRedirectContext
 
 <div class="container">
     <h1 class="title">Sign in</h1>
@@ -59,15 +58,19 @@
 
             var data = $"{user.Id}|{token}";
 
-            if (!string.IsNullOrWhiteSpace(signInRedirectContext.ReturnUrl))
+            var parsedQuery = System.Web.HttpUtility.ParseQueryString(new Uri(navigationManager.Uri).Query);
+
+            var returnUrl = parsedQuery["returnUrl"];
+
+            if (!string.IsNullOrWhiteSpace(returnUrl))
             {
-                data += $"|{signInRedirectContext.ReturnUrl}";
+                data += $"|{returnUrl}";
             }
 
             var protector = dataProtectionProvider.CreateProtector("SignIn");
 
             var pdata = protector.Protect(data);
-            
+
             navigationManager.NavigateTo("/account/signinactual?t=" + pdata, forceLoad: true);
         }
         else

--- a/src/BlazorAuthenticationSample.Client/Features/Security/Components/NotAuthorizedHandler.razor
+++ b/src/BlazorAuthenticationSample.Client/Features/Security/Components/NotAuthorizedHandler.razor
@@ -1,6 +1,5 @@
 ﻿@inject AuthenticationStateProvider authenticationStateProvider
 @inject NavigationManager navigationManager
-@inject SignInRedirectContext signInRedirectContext
 
 @if (showNotAuthorizedMessage)
 {
@@ -24,9 +23,7 @@
         if (!state.User.Identity.IsAuthenticated)
         {
             // If the user is not authenticated redirect them to the sign in page
-
-            signInRedirectContext.ReturnUrl = new Uri(navigationManager.Uri).PathAndQuery;
-            navigationManager.NavigateTo("/account/signin");
+            navigationManager.NavigateTo("/account/signin?returnUrl=" + System.Net.WebUtility.UrlEncode(new Uri(navigationManager.Uri).PathAndQuery));
         }
         else
         {

--- a/src/BlazorAuthenticationSample.Client/Features/SignInRedirectContext.cs
+++ b/src/BlazorAuthenticationSample.Client/Features/SignInRedirectContext.cs
@@ -1,7 +1,0 @@
-﻿namespace BlazorAuthenticationSample.Client.Features
-{
-    public class SignInRedirectContext
-    {
-        public string ReturnUrl { get; set; }
-    }
-}

--- a/src/BlazorAuthenticationSample.Client/Startup.cs
+++ b/src/BlazorAuthenticationSample.Client/Startup.cs
@@ -1,14 +1,13 @@
+using BlazorAuthenticationSample.Client.Data;
+using BlazorAuthenticationSample.Client.Features.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using BlazorAuthenticationSample.Client.Data;
-using BlazorAuthenticationSample.Client.Features.Identity;
-using BlazorAuthenticationSample.Client.Features;
 
 namespace BlazorAuthenticationSample.Client
 {
@@ -46,8 +45,6 @@ namespace BlazorAuthenticationSample.Client
             services.AddControllers();
             services.AddServerSideBlazor();
             services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<IdentityUser>>();
-
-            services.AddSingleton<SignInRedirectContext>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, DbContextOptions<ApplicationDbContext> identityDbContextOptions, UserManager<IdentityUser> userManager, RoleManager<IdentityRole> roleManager)


### PR DESCRIPTION
instead of injected service.

Cloud not get scoped to work any way as navigation from NotAuthorizedHandler seemed to do a full page load even with forceReload: false, causing a new scope and the returnurl value to be lost. Using returnUrl query parameter works better.....

Fixes #1